### PR TITLE
MeTTa Writer Property Handling & Load Endpoint Improvements

### DIFF
--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/MeTTaWriter.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/MeTTaWriter.java
@@ -75,12 +75,37 @@ public class MeTTaWriter implements Writer {
                 if (value instanceof List) {
                     result.append("(");
                     List<?> list = (List<?>) value;
-                    for (int i = 0; i < list.size(); i++) {
-                        result.append(checkProperty(list.get(i).toString()));
-                        if (i < list.size() - 1) {
-                            result.append(" ");
+                    
+                    if (this.writerType.equals("mork")) {
+                        // For mork writer, ensure the entire concatenated list doesn't exceed 1000 chars
+                        StringBuilder listContent = new StringBuilder();
+                        for (int i = 0; i < list.size(); i++) {
+                            String processedItem = checkProperty(list.get(i).toString());
+                            String separator = (i < list.size() - 1) ? " " : "";
+                            String itemWithSeparator = processedItem + separator;
+                            
+                            // Check if adding this item would exceed the limit
+                            if (listContent.length() + itemWithSeparator.length() > 1000) {
+                                // If this is the first item and it's still too long, truncate it
+                                if (listContent.length() == 0) {
+                                    listContent.append(processedItem.substring(0, 1000));
+                                }
+                                break; // Stop adding more items
+                            }
+                            
+                            listContent.append(itemWithSeparator);
+                        }
+                        result.append(listContent);
+                    } else {
+                        // Original logic for non-mork writers
+                        for (int i = 0; i < list.size(); i++) {
+                            result.append(checkProperty(list.get(i).toString()));
+                            if (i < list.size() - 1) {
+                                result.append(" ");
+                            }
                         }
                     }
+                    
                     result.append(")");
                 } else {
                     result.append(checkProperty(value.toString()));
@@ -123,7 +148,7 @@ public class MeTTaWriter implements Writer {
         
         StringBuilder result = new StringBuilder();
         result.append("(").append(label).append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
-              .append("(").append(targetLabel).append(" ").append(targetId).append("))");
+            .append("(").append(targetLabel).append(" ").append(targetId).append("))");
         
         // Add properties
         for (Map.Entry<String, Object> prop : properties.entrySet()) {
@@ -131,8 +156,8 @@ public class MeTTaWriter implements Writer {
             Object value = prop.getValue();
             
             result.append("\n(").append(key).append(" (").append(label)
-                  .append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
-                  .append("(").append(targetLabel).append(" ").append(targetId).append(")) ");
+                .append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
+                .append("(").append(targetLabel).append(" ").append(targetId).append(")) ");
             
             // Handle null or empty values
             if (value == null || value.toString().isEmpty()) {
@@ -142,12 +167,37 @@ public class MeTTaWriter implements Writer {
                 if (value instanceof List) {
                     result.append("(");
                     List<?> list = (List<?>) value;
-                    for (int i = 0; i < list.size(); i++) {
-                        result.append(checkProperty(list.get(i).toString()));
-                        if (i < list.size() - 1) {
-                            result.append(" ");
+                    
+                    if (this.writerType.equals("mork")) {
+                        // For mork writer, ensure the entire concatenated list doesn't exceed 1000 chars
+                        StringBuilder listContent = new StringBuilder();
+                        for (int i = 0; i < list.size(); i++) {
+                            String processedItem = checkProperty(list.get(i).toString());
+                            String separator = (i < list.size() - 1) ? " " : "";
+                            String itemWithSeparator = processedItem + separator;
+                            
+                            // Check if adding this item would exceed the limit
+                            if (listContent.length() + itemWithSeparator.length() > 1000) {
+                                // If this is the first item and it's still too long, truncate it
+                                if (listContent.length() == 0) {
+                                    listContent.append(processedItem.substring(0, 1000));
+                                }
+                                break; // Stop adding more items
+                            }
+                            
+                            listContent.append(itemWithSeparator);
+                        }
+                        result.append(listContent);
+                    } else {
+                        // Original logic for non-mork writers
+                        for (int i = 0; i < list.size(); i++) {
+                            result.append(checkProperty(list.get(i).toString()));
+                            if (i < list.size() - 1) {
+                                result.append(" ");
+                            }
                         }
                     }
+                    
                     result.append(")");
                 } else {
                     result.append(checkProperty(value.toString()));

--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/MeTTaWriter.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/MeTTaWriter.java
@@ -65,9 +65,12 @@ public class MeTTaWriter implements Writer {
             String key = prop.getKey();
             Object value = prop.getValue();
             
-            if (value != null && !value.toString().isEmpty()) {
-                result.append("\n(").append(key).append(" (").append(label).append(" ").append(id).append(") ");
-                
+            result.append("\n(").append(key).append(" (").append(label).append(" ").append(id).append(") ");
+            
+            // Handle null or empty values
+            if (value == null || value.toString().isEmpty()) {
+                result.append("N/A");
+            } else {
                 // Handle different property types
                 if (value instanceof List) {
                     result.append("(");
@@ -82,9 +85,9 @@ public class MeTTaWriter implements Writer {
                 } else {
                     result.append(checkProperty(value.toString()));
                 }
-                
-                result.append(")");
             }
+            
+            result.append(")");
         }
         
         return result.toString();
@@ -127,11 +130,14 @@ public class MeTTaWriter implements Writer {
             String key = prop.getKey();
             Object value = prop.getValue();
             
-            if (value != null && !value.toString().isEmpty()) {
-                result.append("\n(").append(key).append(" (").append(label)
-                      .append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
-                      .append("(").append(targetLabel).append(" ").append(targetId).append(")) ");
-                
+            result.append("\n(").append(key).append(" (").append(label)
+                  .append(" (").append(sourceLabel).append(" ").append(sourceId).append(") ")
+                  .append("(").append(targetLabel).append(" ").append(targetId).append(")) ");
+            
+            // Handle null or empty values
+            if (value == null || value.toString().isEmpty()) {
+                result.append("N/A");
+            } else {
                 // Handle different property types
                 if (value instanceof List) {
                     result.append("(");
@@ -146,9 +152,9 @@ public class MeTTaWriter implements Writer {
                 } else {
                     result.append(checkProperty(value.toString()));
                 }
-                
-                result.append(")");
             }
+            
+            result.append(")");
         }
         
         return result.toString();


### PR DESCRIPTION
## Summary
Fixes property handling issues in MeTTa writer and adds file upload flexibility to the load endpoint.

## Changes

### 1. MeTTa Writer Property Fixes (`MeTTaWriter.java`)
- **Null/Empty Properties**: Now outputs "N/A" for null/empty properties instead of skipping them
- **Mork List Length**: Fixed concatenated list properties exceeding 1000 char limit for mork writer type

### 2. Flexible Load Endpoint (`jobs.py`)
- **Direct File Upload**: `/api/load` now accepts files directly OR via session (not both)
- **Backward Compatible**: Existing session-based workflows unchanged

## Usage Examples

**Session-based (existing):**
```bash
curl -X POST "/api/load" -F "session_id=abc123" -F "config=..."
```

**Direct upload (new):**
```bash
curl -X POST "/api/load" -F "files=@data.csv" -F "config=..."
```

## Impact
- **Data Completeness**: All properties visible in MeTTa output
- **Mork Stability**: Prevents downstream errors from oversized properties  
- **API Flexibility**: Users can choose session or direct upload workflow