### PR TITLE
Add `normalize_schema` function and improve prompt template (v2)

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -170,7 +170,7 @@ async def load_data(
             shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=500, detail=f"Error processing request: {str(e)}")
 
-@router.post("/suggest-schema", response_model=SuggestSchemaResponse)
+@router.post("/suggest-schema", response_model=JSONResponse)
 async def suggest_schema(request: SuggestSchemaRequest):
     """Generate schema suggestions from data source descriptions using LLM."""
     try:
@@ -182,11 +182,16 @@ async def suggest_schema(request: SuggestSchemaRequest):
         # Generate schema using LLM service
         suggested_schema = await schema_suggestion_service.suggest_schema(request.dataSources)
         
-        return SuggestSchemaResponse(
-            schema=suggested_schema,
-            message=f"Schema generated successfully with {len(suggested_schema.nodes)} nodes and {len(suggested_schema.edges)} edges"
-        )
+        # return SuggestSchemaResponse(
+        #     schema=suggested_schema,
+        #     message=f"Schema generated successfully with {len(suggested_schema.nodes)} nodes and {len(suggested_schema.edges)} edges"
+        # )
         
+        return JSONResponse(
+            content=suggested_schema,
+            status_code=200,
+            headers={"Content-Type": "application/json"}
+        )
     except Exception as e:
         print(f"Error in suggest_schema: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error generating schema: {str(e)}")

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -170,7 +170,7 @@ async def load_data(
             shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=500, detail=f"Error processing request: {str(e)}")
 
-@router.post("/suggest-schema", response_model=JSONResponse)
+@router.post("/suggest-schema")
 async def suggest_schema(request: SuggestSchemaRequest):
     """Generate schema suggestions from data source descriptions using LLM."""
     try:

--- a/app/prompts/schema_suggestion_v2.txt
+++ b/app/prompts/schema_suggestion_v2.txt
@@ -1,0 +1,613 @@
+I have an array of data source objects describing a csv file. I want to convert them into a knowledge graph schema. Some of the data source objects represent entities and others represent connections between entities. Entities implement the interface "Entity" and connections implement the interface "Connection". Each object in the input data sources array implements the interface "DataSource".
+
+```typescript
+interface DataSource {
+  id: string;
+  file: File;
+  columns: string[];
+  sampleRow: string[];
+}
+
+interface Node {
+  id: string;
+  type: "entity";
+  position: {x: 0, y: 0};
+  data: {
+    name: string;
+    table: string;
+    primaryKey: string;
+    properties: {
+      [key: string]: Property;
+    };
+  };
+}
+
+interface Connection {
+  id: string;
+  type: "relation";
+  source: string;
+  target: string;
+  name: string;
+  data: {
+    [key: string]: ConnectionType;
+  };
+}
+
+interface ConnectionType {
+  name: string;
+  reversed: boolean;
+  table: string;
+  source: string;
+  target: string;
+  error?: { [key: string]: string };
+  properties: {
+    [key: string]: Property;
+  };
+}
+
+interface Property {
+  name?: string;
+  col: string;
+  type: 'int' | 'text' | 'double';
+  checked: true;
+}
+
+interface Schema {
+  nodes: Entity[];
+  edges: Connection[];
+}
+```
+
+**Rules:**
+- All of the columns in the "columns" field of the data source needs to be included in the "properties" field of entities and connections.
+- The "table" field is the "id" field of the data source file associated with the entity or connection.
+- Each property may define a unique "name" field to avoid collision with other properties.
+- In the "Connection" interface, "source" and "target" refer to the "id" field of the nodes it is connecting.
+- In the "ConnectionType" interface, "source" and "target" refer to the headers of the data source that contains the IDs of the source and target entities respectively. For example, for a ConnectionType that connects a person entity with a company entity, the "source" and "target" fields maybe set to "person_id" and "company_id" respectively, given those fields are present in the data source headers array.
+- No two nodes can have multiple Connection objects in the schema. If they have multiple relationships, they will have a single Connection object with multiple ConnectionType values set on it. For example, if person and company has "works_at" and "pays_salary_to" relationships, the schema will have a single Connection object for these two entities, with two ConnectionType values set on it each with its own configuration. Since "pays_salary_to" is semantically correct with company set as source and person as target, its "reversed" field will be set to true to indicate its semantic direction.
+- Return only valid JSON. Do not include markdown formatting, triple backticks, or explanations. The response must start with { and end with }.
+
+**Example Data Sources:**
+[
+  {
+    "id":"FxP9qO",
+    "file":{
+      "name":"in_neighborhood.csv",
+      "size":997,
+      "type":"text/csv"
+    },
+    "columns":[
+      "inneighborhood_id",
+      "property_id",
+      "neighborhood_id"
+    ],
+    "sampleRow":[
+      "01JVCZPVRJ1EMHM0ZSY2MYZ0NE",
+      "1",
+      "1"
+    ]
+  },
+  {
+    "id":"IiiTaI",
+    "file":{
+      "name":"knows.csv",
+      "size":8686,
+      "type":"text/csv"
+    },
+    "columns":[
+      "knows_id",
+      "person_id_1",
+      "person_id_2",
+      "relationship"
+    ],
+    "sampleRow":[
+      "01JVD064Z5BYJBFHHTSCD5BNGY",
+      "1",
+      "15",
+      "Friend"
+    ]
+  },
+  {
+    "id":"jc1Pee",
+    "file":{
+      "name":"listed_by.csv",
+      "size":1345,
+      "type":"text/csv"
+    },
+    "columns":[
+      "listedby_id",
+      "property_id",
+      "person_id",
+      "listing_date"
+    ],
+    "sampleRow":[
+      "01JVD07RMJBHP610TG5X8EFQ0J",
+      "1",
+      "192",
+      "8/29/2022"
+    ]
+  },
+  {
+    "id":"VyAbP2",
+    "file":{
+      "name":"lives_in.csv",
+      "size":10652,
+      "type":"text/csv"
+    },
+    "columns":[
+      "livesin_id",
+      "person_id",
+      "property_id",
+      "move_in_date",
+      "move_out_date"
+    ],
+    "sampleRow":[
+      "01JVD09YR2DXQF9SPY99FGZ078",
+      "1",
+      "2",
+      "8/14/2002",
+      "6/30/2011"
+    ]
+  },
+  {
+    "id":"iucEcq",
+    "file":{
+      "name":"nearby.csv",
+      "size":97,
+      "type":"text/csv"
+    },
+    "columns":[
+      "nearby_id",
+      "neighborhood_id_1",
+      "neighborhood_id_2",
+      "distance_km"
+    ],
+    "sampleRow":[
+      "1",
+      "1",
+      "2",
+      "377.66"
+    ]
+  },
+  {
+    "id":"FVOTZQ",
+    "file":{
+      "name":"neighborhood.csv",
+      "size":187,
+      "type":"text/csv"
+    },
+    "columns":[
+      "neighborhood_id",
+      "name",
+      "city",
+      "state"
+    ],
+    "sampleRow":[
+      "1",
+      "Bluestem",
+      "Louisville",
+      "Kentucky"
+    ]
+  },
+  {
+    "id":"bzZjuR",
+    "file":{
+      "name":"owns.csv",
+      "size":2959,
+      "type":"text/csv"
+    },
+    "columns":[
+      "owns_id",
+      "person_id",
+      "property_id",
+      "ownership_start",
+      "ownership_end"
+    ],
+    "sampleRow":[
+      "1",
+      "12",
+      "117",
+      "6/15/2005",
+      "11/17/2006"
+    ]
+  },
+  {
+    "id":"yB1Q34",
+    "file":{
+      "name":"property.csv",
+      "size":2009,
+      "type":"text/csv"
+    },
+    "columns":[
+      "property_id",
+      "address",
+      "city",
+      "state",
+      "zip_code",
+      "property_type",
+      "bedrooms",
+      "bathrooms",
+      "square_feet",
+      "year_built"
+    ],
+    "sampleRow":[
+      "1",
+      "42 Drewry Court",
+      "Atlanta",
+      "GA",
+      "30323",
+      "Ranch",
+      "5",
+      "2",
+      "5420",
+      "2006"
+    ]
+  },
+  {
+    "id":"lausTI",
+    "file":{
+      "name":"person.csv",
+      "size":14814,
+      "type":"text/csv"
+    },
+    "columns":[
+      "person_id",
+      "name",
+      "role",
+      "phone",
+      "email"
+    ],
+    "sampleRow":[
+      "1",
+      "Mirilla Petchell",
+      "VP Product Management",
+      "676-479-5124",
+      "mpetchell0@phpbb.com"
+    ]
+  }
+]
+
+**Example Generated Schema:**
+{
+  "nodes":[
+    {
+      "id":"1",
+      "type":"entity",
+      "position":{
+        "x":0,
+        "y":0
+      },
+      "data":{
+        "properties":{
+          "0pYpg_":{
+            "col":"property_id",
+            "checked":true,
+            "type":"text"
+          },
+          "7lPQFq":{
+            "col":"address",
+            "checked":true,
+            "type":"text"
+          },
+          "Uhm2on":{
+            "col":"city",
+            "checked":true,
+            "type":"text"
+          },
+          "9PJ1vO":{
+            "col":"state",
+            "checked":true,
+            "type":"text"
+          },
+          "95BI7C":{
+            "col":"zip_code",
+            "checked":true,
+            "type":"text"
+          },
+          "Bnak-Z":{
+            "col":"property_type",
+            "checked":true,
+            "type":"text"
+          },
+          "GtvNaz":{
+            "col":"bedrooms",
+            "checked":true,
+            "type":"int"
+          },
+          "RSM1nf":{
+            "col":"bathrooms",
+            "checked":true,
+            "type":"int"
+          },
+          "rwWywg":{
+            "col":"square_feet",
+            "checked":true,
+            "type":"double"
+          },
+          "T-jX-C":{
+            "col":"year_built",
+            "checked":true,
+            "type":"int"
+          }
+        },
+        "error":{
+          
+        },
+        "table":"yB1Q34",
+        "primaryKey":"0pYpg_",
+        "name":"Property"
+      }
+    },
+    {
+      "id":"mCZlJk",
+      "type":"entity",
+      "data":{
+        "properties":{
+          "l6xCud":{
+            "col":"person_id",
+            "checked":true,
+            "type":"text"
+          },
+          "nhWY1W":{
+            "col":"name",
+            "checked":true,
+            "type":"text"
+          },
+          "S8shQA":{
+            "col":"role",
+            "checked":true,
+            "type":"text"
+          },
+          "FUvz7I":{
+            "col":"phone",
+            "checked":true,
+            "type":"text"
+          },
+          "YrUqWD":{
+            "col":"email",
+            "checked":true,
+            "type":"text"
+          }
+        },
+        "error":{
+          
+        },
+        "table":"lausTI",
+        "primaryKey":"l6xCud",
+        "name":"Person"
+      },
+      "position":{
+        "x":0,
+        "y":0
+      }
+    },
+    {
+      "id":"wSCtEM",
+      "type":"entity",
+      "data":{
+        "properties":{
+          "EdigiE":{
+            "col":"neighborhood_id",
+            "checked":true,
+            "type":"text"
+          },
+          "jlWlK_":{
+            "col":"name",
+            "checked":true,
+            "type":"text"
+          },
+          "JYmxiy":{
+            "col":"city",
+            "checked":true,
+            "type":"text"
+          },
+          "jJFYaM":{
+            "col":"state",
+            "checked":true,
+            "type":"text"
+          }
+        },
+        "error":{
+          
+        },
+        "table":"FVOTZQ",
+        "primaryKey":"EdigiE",
+        "name":"Neighborhood"
+      },
+      "position":{
+        "x":0,
+        "y":0
+      }
+    }
+  ],
+  "edges":[
+    {
+      "id":"FESYz0",
+      "type":"relation",
+      "source":"1",
+      "target":"mCZlJk",
+      "data":{
+        "ElZIY3":{
+          "properties":{
+            "AQQ_bC":{
+              "col":"listedby_id",
+              "checked":true,
+              "type":"text"
+            },
+            "WAqsIC":{
+              "col":"property_id",
+              "checked":true,
+              "type":"text"
+            },
+            "1eBhYI":{
+              "col":"person_id",
+              "checked":true,
+              "type":"text"
+            },
+            "n_MYlI":{
+              "col":"listing_date",
+              "checked":true,
+              "type":"text"
+            }
+          },
+          "error":{
+            
+          },
+          "table":"jc1Pee",
+          "name":"listed by",
+          "source":"property_id",
+          "target":"person_id"
+        },
+        "9f0eNl":{
+          "properties":{
+            "DJP6YN":{
+              "col":"owns_id",
+              "checked":true,
+              "type":"text"
+            },
+            "XsUlT6":{
+              "col":"person_id",
+              "checked":true,
+              "type":"text"
+            },
+            "TVoPTa":{
+              "col":"property_id",
+              "checked":true,
+              "type":"text"
+            },
+            "iAaIG6":{
+              "col":"ownership_start",
+              "checked":true,
+              "type":"text"
+            },
+            "hz9-3Q":{
+              "col":"ownership_end",
+              "checked":true,
+              "type":"text"
+            }
+          },
+          "error":{
+            
+          },
+          "table":"bzZjuR",
+          "name":"owns",
+          "reversed":true,
+          "source":"person_id",
+          "target":"property_id"
+        },
+        "SzQg4i":{
+          "properties":{
+            "lvsIzb":{
+              "col":"livesin_id",
+              "checked":true,
+              "type":"text"
+            },
+            "2II7no":{
+              "col":"person_id",
+              "checked":true,
+              "type":"text"
+            },
+            "9DU13K":{
+              "col":"property_id",
+              "checked":true,
+              "type":"text"
+            },
+            "HwQbl1":{
+              "col":"move_in_date",
+              "checked":true,
+              "type":"text"
+            },
+            "urXS5h":{
+              "col":"move_out_date",
+              "checked":true,
+              "type":"text"
+            }
+          },
+          "error":{
+            
+          },
+          "table":"VyAbP2",
+          "name":"lives in",
+          "reversed":true,
+          "source":"person_id",
+          "target":"property_id"
+        }
+      }
+    },
+    {
+      "id":"uBviIN",
+      "type":"relation",
+      "source":"1",
+      "target":"wSCtEM",
+      "data":{
+        "lrNk0-":{
+          "properties":{
+            "J8oH3c":{
+              "col":"inneighborhood_id",
+              "checked":true,
+              "type":"text"
+            },
+            "Xqt-8w":{
+              "col":"property_id",
+              "checked":true,
+              "type":"text"
+            },
+            "J4M3xc":{
+              "col":"neighborhood_id",
+              "checked":true,
+              "type":"text"
+            }
+          },
+          "error":{
+            
+          },
+          "table":"FxP9qO",
+          "name":"found in",
+          "source":"property_id",
+          "target":"neighborhood_id"
+        }
+      }
+    },
+    {
+      "id":"1gH5eF",
+      "type":"relation",
+      "source":"mCZlJk",
+      "target":"mCZlJk",
+      "data":{
+        "VtIig5":{
+          "properties":{
+            "e3ypqw":{
+              "col":"knows_id",
+              "checked":true,
+              "type":"text"
+            },
+            "ZSqHhH":{
+              "col":"person_id_1",
+              "checked":true,
+              "type":"text"
+            },
+            "ezEcpK":{
+              "col":"person_id_2",
+              "checked":true,
+              "type":"text"
+            },
+            "ast6eH":{
+              "col":"relationship",
+              "checked":true,
+              "type":"text"
+            }
+          },
+          "error":{
+            
+          },
+          "table":"IiiTaI",
+          "name":"knows",
+          "source":"person_id_1",
+          "target":"person_id_2"
+        }
+      }
+    }
+  ]
+}
+
+Generate a schema for the following data sources: 

--- a/app/prompts/schema_suggestion_v2.txt
+++ b/app/prompts/schema_suggestion_v2.txt
@@ -65,6 +65,7 @@ interface Schema {
 - In the "Connection" interface, "source" and "target" refer to the "id" field of the nodes it is connecting.
 - In the "ConnectionType" interface, "source" and "target" refer to the headers of the data source that contains the IDs of the source and target entities respectively. For example, for a ConnectionType that connects a person entity with a company entity, the "source" and "target" fields maybe set to "person_id" and "company_id" respectively, given those fields are present in the data source headers array.
 - No two nodes can have multiple Connection objects in the schema. If they have multiple relationships, they will have a single Connection object with multiple ConnectionType values set on it. For example, if person and company has "works_at" and "pays_salary_to" relationships, the schema will have a single Connection object for these two entities, with two ConnectionType values set on it each with its own configuration. Since "pays_salary_to" is semantically correct with company set as source and person as target, its "reversed" field will be set to true to indicate its semantic direction.
+- The name of the node or edges must not be space-separated; if they are more than one word, they must be separated by an underscore.
 - Return only valid JSON. Do not include markdown formatting, triple backticks, or explanations. The response must start with { and end with }.
 
 **Example Data Sources:**
@@ -72,7 +73,7 @@ interface Schema {
   {
     "id":"FxP9qO",
     "file":{
-      "name":"in_neighborhood.csv",
+      "name":"data1.csv",
       "size":997,
       "type":"text/csv"
     },
@@ -90,7 +91,7 @@ interface Schema {
   {
     "id":"IiiTaI",
     "file":{
-      "name":"knows.csv",
+      "name":"data2.csv",
       "size":8686,
       "type":"text/csv"
     },
@@ -110,7 +111,7 @@ interface Schema {
   {
     "id":"jc1Pee",
     "file":{
-      "name":"listed_by.csv",
+      "name":"data3.csv",
       "size":1345,
       "type":"text/csv"
     },
@@ -130,7 +131,7 @@ interface Schema {
   {
     "id":"VyAbP2",
     "file":{
-      "name":"lives_in.csv",
+      "name":"ds4.csv",
       "size":10652,
       "type":"text/csv"
     },
@@ -152,7 +153,7 @@ interface Schema {
   {
     "id":"iucEcq",
     "file":{
-      "name":"nearby.csv",
+      "name":"data5.csv",
       "size":97,
       "type":"text/csv"
     },
@@ -172,7 +173,7 @@ interface Schema {
   {
     "id":"FVOTZQ",
     "file":{
-      "name":"neighborhood.csv",
+      "name":"dataset6.csv",
       "size":187,
       "type":"text/csv"
     },
@@ -192,7 +193,7 @@ interface Schema {
   {
     "id":"bzZjuR",
     "file":{
-      "name":"owns.csv",
+      "name":"data7.csv",
       "size":2959,
       "type":"text/csv"
     },
@@ -214,7 +215,7 @@ interface Schema {
   {
     "id":"yB1Q34",
     "file":{
-      "name":"property.csv",
+      "name":"data7.csv",
       "size":2009,
       "type":"text/csv"
     },
@@ -246,7 +247,7 @@ interface Schema {
   {
     "id":"lausTI",
     "file":{
-      "name":"person.csv",
+      "name":"ds8.csv",
       "size":14814,
       "type":"text/csv"
     },
@@ -454,7 +455,7 @@ interface Schema {
             
           },
           "table":"jc1Pee",
-          "name":"listed by",
+          "name":"listed_by",
           "source":"property_id",
           "target":"person_id"
         },
@@ -527,7 +528,7 @@ interface Schema {
             
           },
           "table":"VyAbP2",
-          "name":"lives in",
+          "name":"lives_in",
           "reversed":true,
           "source":"person_id",
           "target":"property_id"
@@ -562,7 +563,7 @@ interface Schema {
             
           },
           "table":"FxP9qO",
-          "name":"found in",
+          "name":"found_in",
           "source":"property_id",
           "target":"neighborhood_id"
         }

--- a/app/services/schema_suggestion_service.py
+++ b/app/services/schema_suggestion_service.py
@@ -1,10 +1,11 @@
 """Schema suggestion service using LLM."""
 
 import asyncio
+from copy import deepcopy
 import json
 import os
 import re
-from typing import List
+from typing import Any, Dict, List
 import httpx
 from ..models.schemas import DataSource, SuggestedSchema
 from ..config import settings
@@ -20,7 +21,7 @@ class SchemaSuggestionService:
         self.api_key = settings.llm_api_key
         self.prompt_file = os.path.join(os.path.dirname(__file__), "..", "prompts", "schema_suggestion_v2.txt")
         
-    async def suggest_schema(self, data_sources: List[DataSource]) -> SuggestedSchema:
+    async def suggest_schema(self, data_sources: List[DataSource]) -> Dict[str, Any]:
         """Generate schema suggestion from data sources."""
         
         # Create the prompt
@@ -39,7 +40,8 @@ class SchemaSuggestionService:
         # Parse and validate the response
         try:
             schema_data = json.loads(schema_json)
-            return SuggestedSchema(**schema_data)
+            schema_data = self._normalize_schema(schema_data)
+            return {"schema": schema_data}
         except Exception as e:
             print(f"Error parsing LLM response: {e}")
             # Return a basic fallback schema
@@ -74,6 +76,51 @@ class SchemaSuggestionService:
         prompt = prompt_template + "\n\n" + json.dumps(data_sources_json, indent=2)
         
         return prompt
+    
+    def _normalize_schema(self, schema):
+        schema = deepcopy(schema)
+
+        # 1. Ensure node IDs match their table values
+        table_to_id = {}
+        for node in schema["nodes"]:
+            node["id"] = node["data"]["table"]
+            table_to_id[node["data"]["name"].lower()] = node["id"]
+
+        # 2. Merge edges between same source/target
+        merged_edges = {}
+        for edge in schema["edges"]:
+            src_id = table_to_id.get(edge["source"], edge["source"])
+            tgt_id = table_to_id.get(edge["target"], edge["target"])
+
+            # Normalize source/target IDs in edges
+            edge["source"] = src_id
+            edge["target"] = tgt_id
+
+            key = (src_id, tgt_id)
+            if key not in merged_edges:
+                merged_edges[key] = {
+                    "id": f"{src_id}-{tgt_id}",
+                    "type": "relation",
+                    "source": src_id,
+                    "target": tgt_id,
+                    "data": {}
+                }
+
+            # Merge all connection types inside data
+            for conn_type, conn_data in edge["data"].items():
+                merged_edges[key]["data"][conn_type] = conn_data
+
+        # 3. Detect reversed edges and merge them into the correct edge
+        for (src, tgt), edge in list(merged_edges.items()):
+            reverse_key = (tgt, src)
+            if reverse_key in merged_edges and reverse_key != (src, tgt):
+                reverse_edge = merged_edges.pop(reverse_key)
+                for conn_type, conn_data in reverse_edge["data"].items():
+                    conn_data["reversed"] = True
+                    edge["data"][conn_type] = conn_data
+
+        schema["edges"] = list(merged_edges.values())
+        return schema
     
     def _get_fallback_prompt(self) -> str:
         """Fallback prompt if file is not found."""

--- a/app/services/schema_suggestion_service.py
+++ b/app/services/schema_suggestion_service.py
@@ -18,7 +18,7 @@ class SchemaSuggestionService:
         # You can configure different LLM providers here
         self.llm_provider =  settings.llm_provider
         self.api_key = settings.llm_api_key
-        self.prompt_file = os.path.join(os.path.dirname(__file__), "..", "prompts", "schema_suggestion.txt")
+        self.prompt_file = os.path.join(os.path.dirname(__file__), "..", "prompts", "schema_suggestion_v2.txt")
         
     async def suggest_schema(self, data_sources: List[DataSource]) -> SuggestedSchema:
         """Generate schema suggestion from data sources."""

--- a/app/services/schema_suggestion_service.py
+++ b/app/services/schema_suggestion_service.py
@@ -21,7 +21,7 @@ class SchemaSuggestionService:
         self.api_key = settings.llm_api_key
         self.prompt_file = os.path.join(os.path.dirname(__file__), "..", "prompts", "schema_suggestion_v2.txt")
         
-    async def suggest_schema(self, data_sources: List[DataSource]) -> Dict[str, Any]:
+    async def suggest_schema(self, data_sources: List[DataSource]):
         """Generate schema suggestion from data sources."""
         
         # Create the prompt


### PR DESCRIPTION
**Summary:**
This PR introduces a new `_normalize_schema` method to ensure schema consistency before further processing, and updates the prompt template to a more tuned v2 version.

**Details:**

### **New: `_normalize_schema` function**

* **Node normalization:**

  * Ensures all node `id` values match their `table` property.
  * Maintains a lookup map from lowercased node names to IDs for consistent reference in edges.
* **Edge merging:**

  * Normalizes `source` and `target` IDs based on the node map.
  * Merges multiple edges between the same source–target pair into a single edge, consolidating all connection types in the `data` field.
* **Reverse edge detection:**

  * Detects reversed source–target edges and merges them into the canonical direction.
  * Marks merged reverse connections with `"reversed": true` in their data.

### **Prompt template update**

* Added a more tuned v2 prompt template for better LLM response quality and consistency.
