### PR TITLE
fix typo in docker-compose example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ make build
 make build-dev
 
 # Traditional method
-docker compose -f docker-compose.dev.yml up -d
+docker-compose -f docker-compose.dev.yml up -d
 ```
 
 ### Service URLs and Access


### PR DESCRIPTION
"docker compose" => "docker-compose"