### PR TITLE
Add Graph Type Support for NetworkX Writer

### DIFF
--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -34,6 +34,7 @@ async def load_data(
     config: str = Form(...),
     schema_json: str = Form(...),
     writer_type: str = Form("metta"),
+    graph_type: str = Form("directed"),
     session_id: str = Form(None),  # Made optional
     files: List[UploadFile] = File(None),  # Made optional
     webhook_url: str = Form(None),
@@ -121,7 +122,8 @@ async def load_data(
             files_dir=files_dir,
             config_data=config_data,
             schema_data=schema_data,
-            writer_type=writer_type
+            writer_type=writer_type,
+            graph_type=graph_type
         )
         
         job_id = response.job_id

--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/executor/LoadOptions.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/executor/LoadOptions.java
@@ -66,6 +66,11 @@ public class LoadOptions implements Serializable {
                          "allowed values are: metta, neo4j, or networkx")  
     public String writerType = "metta";
 
+    @Parameter(names = {"-gt", "--graph-type"}, arity = 1,
+           description = "Choose the graph type for networkx writer, " +
+                         "allowed values are: directed or undirected")
+    public String graphType = "directed";
+
     @Parameter(names = {"--job-id"}, arity = 1,
                description = "The job id of the load task, " +
                              "default is a random UUID")

--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/task/InsertTask.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/task/InsertTask.java
@@ -92,7 +92,7 @@ public abstract class InsertTask implements Runnable {
             // Get or create shared NetworkX writer from context
             this.writer = this.context.getWriter();
             if (this.writer == null) {
-                this.writer = new NetworkXWriter(this.outputDir, this.jobId);
+            this.writer = new NetworkXWriter(this.outputDir, this.jobId, this.context.options().graphType);  
                 this.context.setWriter(this.writer);
             } else if (!(this.writer instanceof NetworkXWriter)) {
                 throw new IllegalStateException(

--- a/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/NetworkXWriter.java
+++ b/hugegraph-loader/src/main/java/org/apache/hugegraph/loader/writer/NetworkXWriter.java
@@ -20,6 +20,7 @@ public class NetworkXWriter implements Writer {
       
     private final String outputDir;  
     private final String jobId;  
+    private final String graphType;  
     private final Map<String, Integer> nodeMapping = new ConcurrentHashMap<>();  
     private final Map<String, Integer> nodeCounters = new ConcurrentHashMap<>();  
     private final Map<String, Integer> edgeCounters = new ConcurrentHashMap<>();  
@@ -27,9 +28,10 @@ public class NetworkXWriter implements Writer {
     private final List<Map<String, Object>> edges = Collections.synchronizedList(new ArrayList<>());  
     private int nodeIdCounter = 0;  
       
-    public NetworkXWriter(String outputDir, String jobId) {  
+    public NetworkXWriter(String outputDir, String jobId, String graphType) {  
         this.outputDir = outputDir;  
         this.jobId = jobId;  
+        this.graphType = graphType;  
           
         try {  
             Files.createDirectories(Paths.get(outputDir));  
@@ -109,7 +111,7 @@ public class NetworkXWriter implements Writer {
         ObjectMapper mapper = new ObjectMapper();  
         ObjectNode graphData = mapper.createObjectNode();  
           
-        graphData.put("directed", true);  
+        graphData.put("directed", "directed".equalsIgnoreCase(this.graphType));  
         graphData.put("multigraph", false);  
           
         ArrayNode nodesArray = mapper.createArrayNode();  
@@ -130,6 +132,7 @@ public class NetworkXWriter implements Writer {
           
         // Write metadata  
         ObjectNode metadata = mapper.createObjectNode();  
+        metadata.put("graph_type", this.graphType);
         metadata.put("node_count", nodes.size());  
         metadata.put("edge_count", edges.size());  
         metadata.set("node_counters", mapper.valueToTree(nodeCounters));  
@@ -148,7 +151,7 @@ public class NetworkXWriter implements Writer {
         System.out.println("Nodes: " + nodes.size() + ", Edges: " + edges.size());  
     }  
       
-    private void convertJsonToPickle(String jsonPath, String pklPath) throws IOException {  
+    protected void convertJsonToPickle(String jsonPath, String pklPath) throws IOException {  
         // Create inline Python script  
         String pythonScript = String.format(  
             "import json\n" +  


### PR DESCRIPTION
## Overview
Adds ability to specify directed or undirected graph type when using the NetworkX writer.

## Changes
- Added `graph_type` parameter to `/api/load` endpoint (defaults to `"directed"`)
- Updated `hugegraph_service.py` to pass graph type through to Java loader
- Added `--graph-type` CLI parameter to `LoadOptions.java`
- Updated `NetworkXWriter.java` to accept and use graph type
- Modified `InsertTask.java` to pass graph type to NetworkX writer

### Metadata
- Graph type now recorded in `networkx_metadata.json`
- Graph type included in `job_metadata.json`

